### PR TITLE
Spike/json explain

### DIFF
--- a/lib/data_services_api/dataset.rb
+++ b/lib/data_services_api/dataset.rb
@@ -61,7 +61,7 @@ module DataServicesApi
     def explain(query)
       sapi_query_params = SapiNTConverter.new(query.to_json).to_sapint_query
       explain_url = "#{data_api}/explain"
-      { sparql: service.api_get_raw(explain_url, sapi_query_params) }
+      service.api_get_json(explain_url, sapi_query_params)
     end
   end
 end

--- a/lib/data_services_api/service.rb
+++ b/lib/data_services_api/service.rb
@@ -26,10 +26,6 @@ module DataServicesApi
       get_json(as_http_api(api), params, options)
     end
 
-    def api_get_raw(api, params, options = {})
-      get_raw(as_http_api(api), params, options)
-    end
-
     def api_post_json(api, json)
       post_json(as_http_api(api), json)
     end
@@ -40,11 +36,6 @@ module DataServicesApi
     def get_json(http_url, params, options)
       response = get_from_api(http_url, 'application/json', params, options)
       parse_json(response.body)
-    end
-
-    def get_raw(http_url, params, options)
-      response = get_from_api(http_url, 'text/plain', params, options)
-      response.body
     end
 
     def get_from_api(http_url, accept_headers, params, options)


### PR DESCRIPTION
This PR comes as a consequence of @mika018 's changes to the API regarding the explain functionality. The JSON should already come in the right format from the API, so extra steps and no longer used functions were removed from the gem