### PR TITLE
Spike/json complete mode

### DIFF
--- a/lib/data_services_api/dataset.rb
+++ b/lib/data_services_api/dataset.rb
@@ -52,6 +52,7 @@ module DataServicesApi
       sapi_query_params = SapiNTConverter.new(query.to_json).to_sapint_query
       sapint_response = service.api_get_json(data_api, sapi_query_params)
       dataset_name = data_api[/[a-z]*$/]
+      json_mode_compact = JSON.parse(query.to_json)['@json_mode'] == 'compact'
     end
 
     def describe(uri)

--- a/lib/data_services_api/dataset.rb
+++ b/lib/data_services_api/dataset.rb
@@ -53,6 +53,8 @@ module DataServicesApi
       sapint_response = service.api_get_json(data_api, sapi_query_params)
       dataset_name = data_api[/[a-z]*$/]
       json_mode_compact = JSON.parse(query.to_json)['@json_mode'] == 'compact'
+      DSAPIResponseConverter.new(sapint_response, dataset_name,
+                                 json_mode_compact: json_mode_compact).to_dsapi_response
     end
 
     def describe(uri)

--- a/lib/data_services_api/dataset.rb
+++ b/lib/data_services_api/dataset.rb
@@ -51,7 +51,7 @@ module DataServicesApi
     def query(query)
       sapi_query_params = SapiNTConverter.new(query.to_json).to_sapint_query
       sapint_response = service.api_get_json(data_api, sapi_query_params)
-      DSAPIResponseConverter.new(sapint_response, data_api).to_dsapi_response
+      dataset_name = data_api[/[a-z]*$/]
     end
 
     def describe(uri)

--- a/lib/data_services_api/dsapi_response_converter.rb
+++ b/lib/data_services_api/dsapi_response_converter.rb
@@ -38,5 +38,19 @@ module DataServicesApi
         ["#{@dataset_name}:#{sapint_key}#{key == '@id' ? '' : key.capitalize}", value]
       end.to_h
     end
+
+    def json_mode_complete(sapint_key, sapint_value)
+      case sapint_key
+      when '@id'
+        return { sapint_key => sapint_value }
+      when 'refMonth'
+        return { "#{@dataset_name}:#{sapint_key}" => { '@value' => sapint_value } }
+      when 'refPeriodStart'
+        return { "#{@dataset_name}:#{sapint_key}" => [{ '@value' => sapint_value }] }
+      end
+      return { "#{@dataset_name}:#{sapint_key}" => [sapint_value] } unless sapint_value.is_a?(Hash)
+
+      { "#{@dataset_name}:#{sapint_key}" => sapint_value }
+    end
   end
 end

--- a/lib/data_services_api/dsapi_response_converter.rb
+++ b/lib/data_services_api/dsapi_response_converter.rb
@@ -2,9 +2,10 @@
 
 module DataServicesApi
   class DSAPIResponseConverter
-    def initialize(sapint_response, data_api)
+    def initialize(sapint_response, dataset_name, json_mode_compact: false)
       @sapint_response = sapint_response
       @dataset_name = dataset_name
+      @json_mode_compact = json_mode_compact
     end
 
     # Converts SAPINT returned JSON format to DSAPI returned JSON format

--- a/lib/data_services_api/dsapi_response_converter.rb
+++ b/lib/data_services_api/dsapi_response_converter.rb
@@ -24,7 +24,11 @@ module DataServicesApi
     end
 
     def to_dsapi_json(sapint_key, sapint_value)
-      dataset_name = @data_api[/[a-z]*$/]
+      # Return different response formats based on the set JSON mode
+      return json_mode_compact(sapint_key, sapint_value) if @json_mode_compact
+
+      json_mode_complete(sapint_key, sapint_value)
+    end
 
       return { sapint_key => sapint_value } if sapint_key == '@id'
       return { "#{dataset_name}:#{sapint_key}" => sapint_value } unless sapint_value.is_a?(Hash)

--- a/lib/data_services_api/dsapi_response_converter.rb
+++ b/lib/data_services_api/dsapi_response_converter.rb
@@ -4,7 +4,7 @@ module DataServicesApi
   class DSAPIResponseConverter
     def initialize(sapint_response, data_api)
       @sapint_response = sapint_response
-      @data_api = data_api
+      @dataset_name = dataset_name
     end
 
     # Converts SAPINT returned JSON format to DSAPI returned JSON format

--- a/lib/data_services_api/dsapi_response_converter.rb
+++ b/lib/data_services_api/dsapi_response_converter.rb
@@ -30,11 +30,12 @@ module DataServicesApi
       json_mode_complete(sapint_key, sapint_value)
     end
 
+    def json_mode_compact(sapint_key, sapint_value)
       return { sapint_key => sapint_value } if sapint_key == '@id'
-      return { "#{dataset_name}:#{sapint_key}" => sapint_value } unless sapint_value.is_a?(Hash)
+      return { "#{@dataset_name}:#{sapint_key}" => sapint_value } unless sapint_value.is_a?(Hash)
 
       sapint_value.map do |key, value|
-        ["#{dataset_name}:#{sapint_key}#{key == '@id' ? '' : key.capitalize}", value]
+        ["#{@dataset_name}:#{sapint_key}#{key == '@id' ? '' : key.capitalize}", value]
       end.to_h
     end
   end


### PR DESCRIPTION
This PR is related to this comment: https://github.com/epimorphics/ukhpi/pull/295#issuecomment-867589770 . It fixes an issue where only `@json_mode: "compact"` was supported (as this was used for PPD), while UKHPI defaults to using `@json_mode: "complete"` because no value is specified in the query (more on that here: https://github.com/epimorphics/data-API/wiki/Data-Query-Syntax). From my tests UKHPI is working properly but please run this to double check (the new API is here: https://github.com/epimorphics/lr-data-api)