### PR TITLE
Add CI actions for Rubocop and Minitest

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,0 +1,17 @@
+name: Check Rubocop compliance
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7
+    - name: Install dependencies (bundle)
+      run: bundle install
+    - name: Run Rubocop
+      run: rubocop

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -3,7 +3,7 @@ name: Check Rubocop compliance
 on: [push, pull_request]
 
 jobs:
-  test:
+  rubocop:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,17 @@
+name: Unit Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7
+    - name: Install dependencies (bundle)
+      run: bundle install
+    - name: Run tests
+      run: rake test

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,12 +9,12 @@ AllCops:
 Layout/LineLength:
   Max: 100
   Exclude:
-    - spec/**/*
+    - test/**/*
 
 Metrics/BlockLength:
   Enabled: true
   Exclude:
-    - spec/**/*
+    - test/**/*
     - data_services_api.gemspec
 
 Style/Documentation:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,8 +7,17 @@ AllCops:
   Exclude:
     - config/unicorn.rb
     - db/**
+  NewCops: enable
 
 Metrics/BlockLength:
   Enabled: true
   Exclude:
     - spec/**/*
+    - data_services_api.gemspec
+
+Style/Documentation:
+  Exclude:
+    - test/**/*
+
+Style/OptionalBooleanParameter:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,13 +1,15 @@
-Layout/LineLength:
-  Max: 100
-  Exclude:
-    - spec/**/*
-
 AllCops:
+  TargetRubyVersion: 2.7
   Exclude:
     - config/unicorn.rb
     - db/**
   NewCops: enable
+
+
+Layout/LineLength:
+  Max: 100
+  Exclude:
+    - spec/**/*
 
 Metrics/BlockLength:
   Enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for DS API rubygem
 
+## 1.1.1 - 2022-01-21
+
+- (Ian) Added GitHub actions to run Rubucop and Minitest tests in CI
+
 ## 1.1.0 - 2021-10-28 (Bogdan)
 
 - Added support for `@json_mode: "complete"` query parameter

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,5 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in data-api.gemspec
 gemspec
+
+gem 'simplecov', require: false

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ require 'bundler/gem_tasks'
 require 'rake/testtask'
 
 Rake::TestTask.new(:test) do |t|
-  t.test_files = FileList['spec/**/*_spec.rb']
+  t.test_files = FileList['test/**/*_test.rb']
 end
 
 task default: :test

--- a/data_services_api.gemspec
+++ b/data_services_api.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'Ruby wrapper for Epimorphics data service API'
   spec.homepage      = 'https://github.com/epimorphics/data-API-ruby'
   spec.license       = ''
-  spec.required_ruby_version = '2.7'
+  spec.required_ruby_version = '>= 2.7'
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/data_services_api.gemspec
+++ b/data_services_api.gemspec
@@ -2,6 +2,7 @@
 
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
 require 'data_services_api/version'
 
 Gem::Specification.new do |spec|
@@ -12,6 +13,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'Ruby wrapper for Epimorphics data service API'
   spec.homepage      = 'https://github.com/epimorphics/data-API-ruby'
   spec.license       = ''
+  spec.required_ruby_version = '2.7'
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
@@ -31,5 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest-vcr'
   spec.add_development_dependency 'mocha'
   spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'webmock'
+  spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/lib/data_services_api.rb
+++ b/lib/data_services_api.rb
@@ -9,8 +9,8 @@ require 'data_services_api/aspect'
 require 'data_services_api/query_generator'
 require 'data_services_api/value'
 require 'data_services_api/service_exception'
-require 'data_services_api/sapint_converter.rb'
-require 'data_services_api/dsapi_response_converter.rb'
+require 'data_services_api/sapint_converter'
+require 'data_services_api/dsapi_response_converter'
 
 # :nodoc:
 module DataServicesApi

--- a/lib/data_services_api/dsapi_response_converter.rb
+++ b/lib/data_services_api/dsapi_response_converter.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
+# :nodoc:
 module DataServicesApi
+  # Adapter-pattern to present a response from SapiNT in the same JSON structure
+  # that the old DsAPI was using
   class DSAPIResponseConverter
     def initialize(sapint_response, dataset_name, json_mode_compact = false)
       @sapint_response = sapint_response
@@ -34,9 +37,9 @@ module DataServicesApi
       return { sapint_key => sapint_value } if sapint_key == '@id'
       return { "#{@dataset_name}:#{sapint_key}" => sapint_value } unless sapint_value.is_a?(Hash)
 
-      sapint_value.map do |key, value|
-        ["#{@dataset_name}:#{sapint_key}#{key == '@id' ? '' : key.capitalize}", value]
-      end.to_h
+      sapint_value.transform_keys do |key|
+        "#{@dataset_name}:#{sapint_key}#{key == '@id' ? '' : key.capitalize}"
+      end
     end
 
     def json_mode_complete(sapint_key, sapint_value)

--- a/lib/data_services_api/sapint_converter.rb
+++ b/lib/data_services_api/sapint_converter.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 module DataServicesApi
-  class SapiNTConverter
+  # Transformer to convert queries using the DsAPI query DSL
+  # into an equivalent SapiNT query URL string
+  class SapiNTConverter # rubocop:disable Metrics/ClassLength
     def initialize(dsapi_query)
       @dsapi_query = JSON.parse(dsapi_query)
     end
@@ -16,7 +18,7 @@ module DataServicesApi
 
     private
 
-    def sapint_query(key, value)
+    def sapint_query(key, value) # rubocop:disable Metrics/MethodLength
       case key
       when '@sort'
         sort(value)
@@ -32,10 +34,14 @@ module DataServicesApi
     end
 
     def sort(values)
-      values.map do |value|
-        sort_prop = value.key?('@up') ? "+#{remove_prefix(value['@up'])}" : "-#{remove_prefix(value['@down'])}"
+      values.to_h do |value|
+        sort_prop = if value.key?('@up')
+                      "+#{remove_prefix(value['@up'])}"
+                    else
+                      "-#{remove_prefix(value['@down'])}"
+                    end
         ['_sort', sort_prop]
-      end.to_h
+      end
     end
 
     def count(value)
@@ -66,7 +72,7 @@ module DataServicesApi
       relation(relation, attribute, relation_json)
     end
 
-    def relation(relation, attribute, json)
+    def relation(relation, attribute, json) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength
       case relation
       when '@eq'
         eq(attribute, json)

--- a/lib/data_services_api/service.rb
+++ b/lib/data_services_api/service.rb
@@ -130,7 +130,7 @@ module DataServicesApi
         Rails.logger.info(msg)
         throw msg
       else
-        throw 'JSON result was not parsed correctly: ' + json.slice(0, 1000)
+        throw "JSON result was not parsed correctly: #{json.slice(0, 1000)}"
       end
     end
   end

--- a/lib/data_services_api/value.rb
+++ b/lib/data_services_api/value.rb
@@ -4,25 +4,27 @@ module DataServicesApi
   # Encapsulates a single value coming back from the API
   class Value < Hash
     def initialize(base = {}, adds = {})
+      super
+
       merge!(base)
         .merge!(adds)
       freeze
     end
 
     def value
-      self[:"@value"]
+      self[:@value]
     end
 
     def type
-      self[:"@type"]
+      self[:@type]
     end
 
     def uri
-      self[:"@id"]
+      self[:@id]
     end
 
     def with_uri(uri)
-      Value.new(self, "@id": uri)
+      Value.new(self, '@id': uri)
     end
 
     def self.uri(uri)
@@ -30,7 +32,7 @@ module DataServicesApi
     end
 
     def with_typed_value(value, type)
-      Value.new(self, "@value": value, "@type": type)
+      Value.new(self, '@value': value, '@type': type)
     end
 
     def with_year_month(year, month)

--- a/lib/data_services_api/value.rb
+++ b/lib/data_services_api/value.rb
@@ -4,7 +4,7 @@ module DataServicesApi
   # Encapsulates a single value coming back from the API
   class Value < Hash
     def initialize(base = {}, adds = {})
-      super
+      super()
 
       merge!(base)
         .merge!(adds)

--- a/lib/data_services_api/version.rb
+++ b/lib/data_services_api/version.rb
@@ -2,6 +2,6 @@
 
 # :nodoc:
 module DataServicesApi
-  VERSION = '1.1.0'
+  VERSION = '1.1.1'
   MAJOR, MINOR, PATCH = VERSION.split('.')
 end

--- a/spec/data_services_api/data_services_api_spec.rb
+++ b/spec/data_services_api/data_services_api_spec.rb
@@ -8,7 +8,7 @@ describe 'DataServicesAPI', 'the data services API' do
   end
 
   it 'should be constructable with a given URL' do
-    dsapi = DataServicesApi::Service .new(url: 'foo/bar')
+    dsapi = DataServicesApi::Service.new(url: 'foo/bar')
     _(dsapi.url).must_match(%r{foo/bar})
   end
 end

--- a/spec/data_services_api/value_spec.rb
+++ b/spec/data_services_api/value_spec.rb
@@ -18,24 +18,24 @@ describe 'DataServicesApi::Value' do
   it 'should specify a URI' do
     v1 = v.with_uri('http://foo/bar')
     _(v1.size).must_equal 1
-    _(v1[:"@id"]).must_equal 'http://foo/bar'
+    _(v1[:@id]).must_equal 'http://foo/bar'
     _(v1.uri).must_equal 'http://foo/bar'
   end
 
   it 'should have a factory shortcut for creating a URI value' do
     v = DataServicesApi::Value.uri('http://fubar.com')
     _(v.size).must_equal 1
-    _(v[:"@id"]).must_equal 'http://fubar.com'
+    _(v[:@id]).must_equal 'http://fubar.com'
   end
 
   it 'should specify type and value' do
     v1 = v.with_typed_value('foo', 'http://fakexsd.org/bar')
     _(v1.size).must_equal 2
 
-    _(v1[:"@value"]).must_equal 'foo'
+    _(v1[:@value]).must_equal 'foo'
     _(v1.value).must_equal 'foo'
 
-    _(v1[:"@type"]).must_equal 'http://fakexsd.org/bar'
+    _(v1[:@type]).must_equal 'http://fakexsd.org/bar'
     _(v1.type).must_equal 'http://fakexsd.org/bar'
   end
 

--- a/test/data_services_api/data_services_api_test.rb
+++ b/test/data_services_api/data_services_api_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require './spec/minitest_helper'
+require './test/minitest_helper'
 
 describe 'DataServicesAPI', 'the data services API' do
   it 'should have a semantic version' do

--- a/test/data_services_api/dataset_test.rb
+++ b/test/data_services_api/dataset_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require './spec/minitest_helper'
+require './test/minitest_helper'
 
 describe 'DataServiceApi::Dataset' do
   before do

--- a/test/data_services_api/dsapi_response_converter_test.rb
+++ b/test/data_services_api/dsapi_response_converter_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require './spec/minitest_helper'
+require './test/minitest_helper'
 
 describe 'DataServicesApi::DSAPIResponseConverter' do
   describe 'PPD' do

--- a/test/data_services_api/query_generator_test.rb
+++ b/test/data_services_api/query_generator_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require './spec/minitest_helper'
+require './test/minitest_helper'
 
 describe 'DataServiceApi::QueryGenerator' do
   before do

--- a/test/data_services_api/sapint_converter_test.rb
+++ b/test/data_services_api/sapint_converter_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require './spec/minitest_helper'
+require './test/minitest_helper'
 
 describe 'DataServicesApi::SapiNTConverter' do
   let(:dsapi_query) do

--- a/test/data_services_api/service_test.rb
+++ b/test/data_services_api/service_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require './spec/minitest_helper'
+require './test/minitest_helper'
 
 describe 'DataServicesAPI::Service', vcr: true do
   before do

--- a/test/data_services_api/value_test.rb
+++ b/test/data_services_api/value_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require './spec/minitest_helper'
+require './test/minitest_helper'
 
 describe 'DataServicesApi::Value' do
   let(:v) { DataServicesApi::Value.new }

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -2,6 +2,11 @@
 
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
+require 'simplecov'
+SimpleCov.start 'test_frameworks' do
+  enable_coverage :branch
+end
+
 require 'yajl'
 require 'minitest'
 require 'minitest/autorun'


### PR DESCRIPTION
Set up CI using Github actions. Each push will run both Rubocop and the Minitest test suite.

- Update .rubocop.yml and fix RuboCop warnings
- Add GitHub action to run Rubocop checks
- Tweak required Ruby version
- Set TargetRubyVersion
- Add a GitHub workflow action to run unit tests
- Update version and changelog
