### PR TITLE
Add Prometheus metrics support

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,3 +15,5 @@ jobs:
       run: bundle install
     - name: Run tests
       run: rake test
+      env:
+        API_URL: http://localhost:8080

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog for DS API rubygem
 
+## 1.2.0 - 2022-01-27
+
+- (Ian) Added `ActiveSupport` instrumentation calls to allow collecting
+  of metrics on API calls
+
 ## 1.1.1 - 2022-01-21
 
 - (Ian) Added GitHub actions to run Rubucop and Minitest tests in CI

--- a/fixtures/vcr_cassettes/test_0002_should_accept_a_query_and_return_the_result.yml
+++ b/fixtures/vcr_cassettes/test_0002_should_accept_a_query_and_return_the_result.yml
@@ -72,4 +72,40 @@ http_interactions:
       encoding: UTF-8
       string: '{"meta":{"@id":"http://localhost//landregistry/id/ukhpi?_limit=1&_sort=-refMonth&mineq-refMonth=2019-01&refRegion=http%3A%2F%2Flandregistry.data.gov.uk%2Fid%2Fregion%2Funited-kingdom","publisher":"","license":"","licenseName":"","comment":"","version":"0.1","hasFormat":["http://localhost//landregistry/id/ukhpi.rdf?_limit=1&_sort=-refMonth&mineq-refMonth=2019-01&refRegion=http%3A%2F%2Flandregistry.data.gov.uk%2Fid%2Fregion%2Funited-kingdom","http://localhost//landregistry/id/ukhpi.html?_limit=1&_sort=-refMonth&mineq-refMonth=2019-01&refRegion=http%3A%2F%2Flandregistry.data.gov.uk%2Fid%2Fregion%2Funited-kingdom","http://localhost//landregistry/id/ukhpi.geojson?_limit=1&_sort=-refMonth&mineq-refMonth=2019-01&refRegion=http%3A%2F%2Flandregistry.data.gov.uk%2Fid%2Fregion%2Funited-kingdom","http://localhost//landregistry/id/ukhpi.csv?_limit=1&_sort=-refMonth&mineq-refMonth=2019-01&refRegion=http%3A%2F%2Flandregistry.data.gov.uk%2Fid%2Fregion%2Funited-kingdom","http://localhost//landregistry/id/ukhpi.ttl?_limit=1&_sort=-refMonth&mineq-refMonth=2019-01&refRegion=http%3A%2F%2Flandregistry.data.gov.uk%2Fid%2Fregion%2Funited-kingdom","http://localhost//landregistry/id/ukhpi.json?_limit=1&_sort=-refMonth&mineq-refMonth=2019-01&refRegion=http%3A%2F%2Flandregistry.data.gov.uk%2Fid%2Fregion%2Funited-kingdom"],"limit":1},"items":[{"@id":"http://landregistry.data.gov.uk/data/ukhpi/region/united-kingdom/month/2021-08","refRegion":{"@id":"http://landregistry.data.gov.uk/id/region/united-kingdom"},"refMonth":"2021-08","averagePrice":264244,"averagePriceSA":260117,"housePriceIndex":138.59,"housePriceIndexSA":136.43,"percentageAnnualChange":10.56,"percentageChange":2.93,"averagePriceDetached":411649,"housePriceIndexDetached":143.07,"percentageChangeDetached":4.13,"percentageAnnualChangeDetached":13.08,"averagePriceSemiDetached":254115,"housePriceIndexSemiDetached":142.14,"percentageChangeSemiDetached":3.06,"percentageAnnualChangeSemiDetached":11.05,"averagePriceTerraced":214083,"housePriceIndexTerraced":139.07,"percentageChangeTerraced":3.02,"percentageAnnualChangeTerraced":9.94,"averagePriceFlatMaisonette":220756,"housePriceIndexFlatMaisonette":127.46,"percentageChangeFlatMaisonette":0.89,"percentageAnnualChangeFlatMaisonette":7.27,"refPeriodStart":"2021-08-01","refPeriodDuration":1}]}'
   recorded_at: Thu, 28 Oct 2021 11:37:18 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/landregistry/id/ukhpi?_limit=1&_sort=-refMonth&mineq-refMonth=2019-01&refRegion=http://landregistry.data.gov.uk/id/region/united-kingdom
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.9.3
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Sleuth-Trace-Id:
+      - 5dee87b14b0f93ef
+      Sleuth-Span-Id:
+      - 5dee87b14b0f93ef
+      Vary:
+      - Accept
+      Cache-Control:
+      - max-age=0
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2309'
+      Date:
+      - Tue, 25 Jan 2022 17:56:22 GMT
+    body:
+      encoding: UTF-8
+      string: '{"meta":{"@id":"http://localhost//landregistry/id/ukhpi?_limit=1&_sort=-refMonth&mineq-refMonth=2019-01&refRegion=http%3A%2F%2Flandregistry.data.gov.uk%2Fid%2Fregion%2Funited-kingdom","publisher":"","license":"","licenseName":"","comment":"","version":"0.1","hasFormat":["http://localhost//landregistry/id/ukhpi.rdf?_limit=1&_sort=-refMonth&mineq-refMonth=2019-01&refRegion=http%3A%2F%2Flandregistry.data.gov.uk%2Fid%2Fregion%2Funited-kingdom","http://localhost//landregistry/id/ukhpi.html?_limit=1&_sort=-refMonth&mineq-refMonth=2019-01&refRegion=http%3A%2F%2Flandregistry.data.gov.uk%2Fid%2Fregion%2Funited-kingdom","http://localhost//landregistry/id/ukhpi.geojson?_limit=1&_sort=-refMonth&mineq-refMonth=2019-01&refRegion=http%3A%2F%2Flandregistry.data.gov.uk%2Fid%2Fregion%2Funited-kingdom","http://localhost//landregistry/id/ukhpi.csv?_limit=1&_sort=-refMonth&mineq-refMonth=2019-01&refRegion=http%3A%2F%2Flandregistry.data.gov.uk%2Fid%2Fregion%2Funited-kingdom","http://localhost//landregistry/id/ukhpi.ttl?_limit=1&_sort=-refMonth&mineq-refMonth=2019-01&refRegion=http%3A%2F%2Flandregistry.data.gov.uk%2Fid%2Fregion%2Funited-kingdom","http://localhost//landregistry/id/ukhpi.json?_limit=1&_sort=-refMonth&mineq-refMonth=2019-01&refRegion=http%3A%2F%2Flandregistry.data.gov.uk%2Fid%2Fregion%2Funited-kingdom"],"limit":1},"items":[{"@id":"http://landregistry.data.gov.uk/data/ukhpi/region/united-kingdom/month/2021-10","refRegion":{"@id":"http://landregistry.data.gov.uk/id/region/united-kingdom"},"refMonth":"2021-10","averagePrice":268349,"averagePriceSA":264786,"housePriceIndex":140.74,"housePriceIndexSA":138.87,"percentageAnnualChange":10.17,"percentageChange":-1.11,"averagePriceDetached":425121,"housePriceIndexDetached":147.75,"percentageChangeDetached":0.75,"percentageAnnualChangeDetached":13.99,"averagePriceSemiDetached":256537,"housePriceIndexSemiDetached":143.49,"percentageChangeSemiDetached":-1.64,"percentageAnnualChangeSemiDetached":10.39,"averagePriceTerraced":216481,"housePriceIndexTerraced":140.62,"percentageChangeTerraced":-2.88,"percentageAnnualChangeTerraced":8.79,"averagePriceFlatMaisonette":222381,"housePriceIndexFlatMaisonette":128.40,"percentageChangeFlatMaisonette":-0.17,"percentageAnnualChangeFlatMaisonette":6.63,"refPeriodStart":"2021-10-01","refPeriodDuration":1}]}'
+  recorded_at: Tue, 25 Jan 2022 17:56:23 GMT
 recorded_with: VCR 6.0.0

--- a/fixtures/vcr_cassettes/test_0003_should_retrieve_JSON_with_HTTP_GET.yml
+++ b/fixtures/vcr_cassettes/test_0003_should_retrieve_JSON_with_HTTP_GET.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:8080/landregistry/id/ukhpi?_limit=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.9.3
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Sleuth-Trace-Id:
+      - 9fb9187dcb586943
+      Sleuth-Span-Id:
+      - 9fb9187dcb586943
+      Vary:
+      - Accept
+      Cache-Control:
+      - max-age=0
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1771'
+      Date:
+      - Tue, 25 Jan 2022 17:59:28 GMT
+    body:
+      encoding: UTF-8
+      string: '{"meta":{"@id":"http://localhost//landregistry/id/ukhpi?_limit=1","publisher":"","license":"","licenseName":"","comment":"","version":"0.1","hasFormat":["http://localhost//landregistry/id/ukhpi.html?_limit=1","http://localhost//landregistry/id/ukhpi.geojson?_limit=1","http://localhost//landregistry/id/ukhpi.rdf?_limit=1","http://localhost//landregistry/id/ukhpi.json?_limit=1","http://localhost//landregistry/id/ukhpi.csv?_limit=1","http://localhost//landregistry/id/ukhpi.ttl?_limit=1"],"limit":1},"items":[{"@id":"http://landregistry.data.gov.uk/data/ukhpi/region/rutland/month/1999-05","refRegion":{"@id":"http://landregistry.data.gov.uk/id/region/rutland"},"refMonth":"1999-05","averagePrice":86936,"housePriceIndex":34.68,"percentageAnnualChange":7.75,"percentageChange":3.35,"salesVolume":77,"averagePriceDetached":118808,"housePriceIndexDetached":35.49,"percentageChangeDetached":3.21,"percentageAnnualChangeDetached":7.56,"averagePriceSemiDetached":71348,"housePriceIndexSemiDetached":34.29,"percentageChangeSemiDetached":3.42,"percentageAnnualChangeSemiDetached":7.91,"averagePriceTerraced":61817,"housePriceIndexTerraced":33.79,"percentageChangeTerraced":3.60,"percentageAnnualChangeTerraced":7.55,"averagePriceFlatMaisonette":42370,"housePriceIndexFlatMaisonette":34.70,"percentageChangeFlatMaisonette":3.61,"percentageAnnualChangeFlatMaisonette":9.47,"averagePriceNewBuild":99439,"housePriceIndexNewBuild":33.50,"percentageChangeNewBuild":3.17,"percentageAnnualChangeNewBuild":8.12,"salesVolumeNewBuild":21,"averagePriceExistingProperty":85036,"housePriceIndexExistingProperty":34.89,"percentageChangeExistingProperty":3.38,"percentageAnnualChangeExistingProperty":7.88,"salesVolumeExistingProperty":56,"refPeriodStart":"1999-05-01","refPeriodDuration":1}]}'
+  recorded_at: Tue, 25 Jan 2022 17:59:28 GMT
+recorded_with: VCR 6.0.0

--- a/fixtures/vcr_cassettes/test_0004_should_retrieve_JSON_with_HTTP_GET.yml
+++ b/fixtures/vcr_cassettes/test_0004_should_retrieve_JSON_with_HTTP_GET.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:8080/landregistry/id/ukhpi?_limit=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.9.3
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Sleuth-Trace-Id:
+      - '0544028a52260dd3'
+      Sleuth-Span-Id:
+      - '0544028a52260dd3'
+      Vary:
+      - Accept
+      Cache-Control:
+      - max-age=0
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1771'
+      Date:
+      - Thu, 27 Jan 2022 11:25:30 GMT
+    body:
+      encoding: UTF-8
+      string: '{"meta":{"@id":"http://localhost//landregistry/id/ukhpi?_limit=1","publisher":"","license":"","licenseName":"","comment":"","version":"0.1","hasFormat":["http://localhost//landregistry/id/ukhpi.html?_limit=1","http://localhost//landregistry/id/ukhpi.geojson?_limit=1","http://localhost//landregistry/id/ukhpi.rdf?_limit=1","http://localhost//landregistry/id/ukhpi.json?_limit=1","http://localhost//landregistry/id/ukhpi.csv?_limit=1","http://localhost//landregistry/id/ukhpi.ttl?_limit=1"],"limit":1},"items":[{"@id":"http://landregistry.data.gov.uk/data/ukhpi/region/rutland/month/1999-05","refRegion":{"@id":"http://landregistry.data.gov.uk/id/region/rutland"},"refMonth":"1999-05","averagePrice":86936,"housePriceIndex":34.68,"percentageAnnualChange":7.75,"percentageChange":3.35,"salesVolume":77,"averagePriceDetached":118808,"housePriceIndexDetached":35.49,"percentageChangeDetached":3.21,"percentageAnnualChangeDetached":7.56,"averagePriceSemiDetached":71348,"housePriceIndexSemiDetached":34.29,"percentageChangeSemiDetached":3.42,"percentageAnnualChangeSemiDetached":7.91,"averagePriceTerraced":61817,"housePriceIndexTerraced":33.79,"percentageChangeTerraced":3.60,"percentageAnnualChangeTerraced":7.55,"averagePriceFlatMaisonette":42370,"housePriceIndexFlatMaisonette":34.70,"percentageChangeFlatMaisonette":3.61,"percentageAnnualChangeFlatMaisonette":9.47,"averagePriceNewBuild":99439,"housePriceIndexNewBuild":33.50,"percentageChangeNewBuild":3.17,"percentageAnnualChangeNewBuild":8.12,"salesVolumeNewBuild":21,"averagePriceExistingProperty":85036,"housePriceIndexExistingProperty":34.89,"percentageChangeExistingProperty":3.38,"percentageAnnualChangeExistingProperty":7.88,"salesVolumeExistingProperty":56,"refPeriodStart":"1999-05-01","refPeriodDuration":1}]}'
+  recorded_at: Thu, 27 Jan 2022 11:25:30 GMT
+recorded_with: VCR 6.0.0

--- a/fixtures/vcr_cassettes/test_0005_should_instrument_an_API_call.yml
+++ b/fixtures/vcr_cassettes/test_0005_should_instrument_an_API_call.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:8080/landregistry/id/ukhpi?_limit=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.9.3
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Sleuth-Trace-Id:
+      - 32a847f9359b336b
+      Sleuth-Span-Id:
+      - 32a847f9359b336b
+      Vary:
+      - Accept
+      Cache-Control:
+      - max-age=0
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1771'
+      Date:
+      - Thu, 27 Jan 2022 11:44:53 GMT
+    body:
+      encoding: UTF-8
+      string: '{"meta":{"@id":"http://localhost//landregistry/id/ukhpi?_limit=1","publisher":"","license":"","licenseName":"","comment":"","version":"0.1","hasFormat":["http://localhost//landregistry/id/ukhpi.html?_limit=1","http://localhost//landregistry/id/ukhpi.geojson?_limit=1","http://localhost//landregistry/id/ukhpi.rdf?_limit=1","http://localhost//landregistry/id/ukhpi.json?_limit=1","http://localhost//landregistry/id/ukhpi.csv?_limit=1","http://localhost//landregistry/id/ukhpi.ttl?_limit=1"],"limit":1},"items":[{"@id":"http://landregistry.data.gov.uk/data/ukhpi/region/rutland/month/1999-05","refRegion":{"@id":"http://landregistry.data.gov.uk/id/region/rutland"},"refMonth":"1999-05","averagePrice":86936,"housePriceIndex":34.68,"percentageAnnualChange":7.75,"percentageChange":3.35,"salesVolume":77,"averagePriceDetached":118808,"housePriceIndexDetached":35.49,"percentageChangeDetached":3.21,"percentageAnnualChangeDetached":7.56,"averagePriceSemiDetached":71348,"housePriceIndexSemiDetached":34.29,"percentageChangeSemiDetached":3.42,"percentageAnnualChangeSemiDetached":7.91,"averagePriceTerraced":61817,"housePriceIndexTerraced":33.79,"percentageChangeTerraced":3.60,"percentageAnnualChangeTerraced":7.55,"averagePriceFlatMaisonette":42370,"housePriceIndexFlatMaisonette":34.70,"percentageChangeFlatMaisonette":3.61,"percentageAnnualChangeFlatMaisonette":9.47,"averagePriceNewBuild":99439,"housePriceIndexNewBuild":33.50,"percentageChangeNewBuild":3.17,"percentageAnnualChangeNewBuild":8.12,"salesVolumeNewBuild":21,"averagePriceExistingProperty":85036,"housePriceIndexExistingProperty":34.89,"percentageChangeExistingProperty":3.38,"percentageAnnualChangeExistingProperty":7.88,"salesVolumeExistingProperty":56,"refPeriodStart":"1999-05-01","refPeriodDuration":1}]}'
+  recorded_at: Thu, 27 Jan 2022 11:44:53 GMT
+recorded_with: VCR 6.0.0

--- a/fixtures/vcr_cassettes/test_0006_should_instrument_a_failed_API_call.yml
+++ b/fixtures/vcr_cassettes/test_0006_should_instrument_a_failed_API_call.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:8080/landregistry/id/ukhpi?_limit=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.9.3
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Sleuth-Trace-Id:
+      - 49602982c1db967f
+      Sleuth-Span-Id:
+      - 49602982c1db967f
+      Vary:
+      - Accept
+      Cache-Control:
+      - max-age=0
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1771'
+      Date:
+      - Thu, 27 Jan 2022 16:48:59 GMT
+    body:
+      encoding: UTF-8
+      string: '{"meta":{"@id":"http://localhost//landregistry/id/ukhpi?_limit=1","publisher":"","license":"","licenseName":"","comment":"","version":"0.1","hasFormat":["http://localhost//landregistry/id/ukhpi.html?_limit=1","http://localhost//landregistry/id/ukhpi.geojson?_limit=1","http://localhost//landregistry/id/ukhpi.rdf?_limit=1","http://localhost//landregistry/id/ukhpi.json?_limit=1","http://localhost//landregistry/id/ukhpi.csv?_limit=1","http://localhost//landregistry/id/ukhpi.ttl?_limit=1"],"limit":1},"items":[{"@id":"http://landregistry.data.gov.uk/data/ukhpi/region/rutland/month/1999-05","refRegion":{"@id":"http://landregistry.data.gov.uk/id/region/rutland"},"refMonth":"1999-05","averagePrice":86936,"housePriceIndex":34.68,"percentageAnnualChange":7.75,"percentageChange":3.35,"salesVolume":77,"averagePriceDetached":118808,"housePriceIndexDetached":35.49,"percentageChangeDetached":3.21,"percentageAnnualChangeDetached":7.56,"averagePriceSemiDetached":71348,"housePriceIndexSemiDetached":34.29,"percentageChangeSemiDetached":3.42,"percentageAnnualChangeSemiDetached":7.91,"averagePriceTerraced":61817,"housePriceIndexTerraced":33.79,"percentageChangeTerraced":3.60,"percentageAnnualChangeTerraced":7.55,"averagePriceFlatMaisonette":42370,"housePriceIndexFlatMaisonette":34.70,"percentageChangeFlatMaisonette":3.61,"percentageAnnualChangeFlatMaisonette":9.47,"averagePriceNewBuild":99439,"housePriceIndexNewBuild":33.50,"percentageChangeNewBuild":3.17,"percentageAnnualChangeNewBuild":8.12,"salesVolumeNewBuild":21,"averagePriceExistingProperty":85036,"housePriceIndexExistingProperty":34.89,"percentageChangeExistingProperty":3.38,"percentageAnnualChangeExistingProperty":7.88,"salesVolumeExistingProperty":56,"refPeriodStart":"1999-05-01","refPeriodDuration":1}]}'
+  recorded_at: Thu, 27 Jan 2022 16:48:59 GMT
+recorded_with: VCR 6.0.0

--- a/fixtures/vcr_cassettes/test_0007_should_instrument_a_failed_API_call.yml
+++ b/fixtures/vcr_cassettes/test_0007_should_instrument_a_failed_API_call.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:8080/ceci/nest/pa/un/page?_limit=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.9.3
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: ''
+    headers:
+      Sleuth-Trace-Id:
+      - 7f56f504f024a745
+      Sleuth-Span-Id:
+      - 7f56f504f024a745
+      Vary:
+      - Accept
+      - Access-Control-Request-Headers
+      - Access-Control-Request-Method
+      - Origin
+      Cache-Control:
+      - max-age=0
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '181'
+      Date:
+      - Thu, 27 Jan 2022 17:45:53 GMT
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "timestamp" : "Thu Jan 27 17:45:53 GMT 2022",
+          "status" : "404",
+          "error" : "Not Found",
+          "message" : "Requested endpoint doesn't exist",
+          "path" : "/ceci/nest/pa/un/page"
+        }
+  recorded_at: Thu, 27 Jan 2022 17:45:53 GMT
+recorded_with: VCR 6.0.0

--- a/fixtures/vcr_cassettes/test_0007_should_instrument_a_failed_API_call.yml
+++ b/fixtures/vcr_cassettes/test_0007_should_instrument_a_failed_API_call.yml
@@ -46,4 +46,50 @@ http_interactions:
           "path" : "/ceci/nest/pa/un/page"
         }
   recorded_at: Thu, 27 Jan 2022 17:45:53 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/ceci/nest/pas/une/page?_limit=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.9.3
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: ''
+    headers:
+      Sleuth-Trace-Id:
+      - b046f8c8b258d522
+      Sleuth-Span-Id:
+      - b046f8c8b258d522
+      Vary:
+      - Accept
+      - Access-Control-Request-Headers
+      - Access-Control-Request-Method
+      - Origin
+      Cache-Control:
+      - max-age=0
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '183'
+      Date:
+      - Fri, 28 Jan 2022 15:09:22 GMT
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "timestamp" : "Fri Jan 28 15:09:22 GMT 2022",
+          "status" : "404",
+          "error" : "Not Found",
+          "message" : "Requested endpoint doesn't exist",
+          "path" : "/ceci/nest/pas/une/page"
+        }
+  recorded_at: Fri, 28 Jan 2022 15:09:22 GMT
 recorded_with: VCR 6.0.0

--- a/fixtures/vcr_cassettes/test_0008_should_log_the_call_to_the_data_API.yml
+++ b/fixtures/vcr_cassettes/test_0008_should_log_the_call_to_the_data_API.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:8080/landregistry/id/ukhpi?_limit=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.9.3
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Sleuth-Trace-Id:
+      - bd7a8cf5b7ff64e8
+      Sleuth-Span-Id:
+      - bd7a8cf5b7ff64e8
+      Vary:
+      - Accept
+      Cache-Control:
+      - max-age=0
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1771'
+      Date:
+      - Thu, 27 Jan 2022 18:49:22 GMT
+    body:
+      encoding: UTF-8
+      string: '{"meta":{"@id":"http://localhost//landregistry/id/ukhpi?_limit=1","publisher":"","license":"","licenseName":"","comment":"","version":"0.1","hasFormat":["http://localhost//landregistry/id/ukhpi.html?_limit=1","http://localhost//landregistry/id/ukhpi.geojson?_limit=1","http://localhost//landregistry/id/ukhpi.rdf?_limit=1","http://localhost//landregistry/id/ukhpi.json?_limit=1","http://localhost//landregistry/id/ukhpi.csv?_limit=1","http://localhost//landregistry/id/ukhpi.ttl?_limit=1"],"limit":1},"items":[{"@id":"http://landregistry.data.gov.uk/data/ukhpi/region/rutland/month/1999-05","refRegion":{"@id":"http://landregistry.data.gov.uk/id/region/rutland"},"refMonth":"1999-05","averagePrice":86936,"housePriceIndex":34.68,"percentageAnnualChange":7.75,"percentageChange":3.35,"salesVolume":77,"averagePriceDetached":118808,"housePriceIndexDetached":35.49,"percentageChangeDetached":3.21,"percentageAnnualChangeDetached":7.56,"averagePriceSemiDetached":71348,"housePriceIndexSemiDetached":34.29,"percentageChangeSemiDetached":3.42,"percentageAnnualChangeSemiDetached":7.91,"averagePriceTerraced":61817,"housePriceIndexTerraced":33.79,"percentageChangeTerraced":3.60,"percentageAnnualChangeTerraced":7.55,"averagePriceFlatMaisonette":42370,"housePriceIndexFlatMaisonette":34.70,"percentageChangeFlatMaisonette":3.61,"percentageAnnualChangeFlatMaisonette":9.47,"averagePriceNewBuild":99439,"housePriceIndexNewBuild":33.50,"percentageChangeNewBuild":3.17,"percentageAnnualChangeNewBuild":8.12,"salesVolumeNewBuild":21,"averagePriceExistingProperty":85036,"housePriceIndexExistingProperty":34.89,"percentageChangeExistingProperty":3.38,"percentageAnnualChangeExistingProperty":7.88,"salesVolumeExistingProperty":56,"refPeriodStart":"1999-05-01","refPeriodDuration":1}]}'
+  recorded_at: Thu, 27 Jan 2022 18:49:22 GMT
+recorded_with: VCR 6.0.0

--- a/lib/data_services_api/version.rb
+++ b/lib/data_services_api/version.rb
@@ -2,6 +2,6 @@
 
 # :nodoc:
 module DataServicesApi
-  VERSION = '1.1.1'
+  VERSION = '1.2.0'
   MAJOR, MINOR, PATCH = VERSION.split('.')
 end

--- a/test/data_services_api/service_test.rb
+++ b/test/data_services_api/service_test.rb
@@ -2,9 +2,37 @@
 
 require './test/minitest_helper'
 
+class MockNotifications
+  attr_reader :instrumentations
+
+  def initialize
+    @instrumentations = []
+  end
+
+  def instrument(*args)
+    @instrumentations << args
+  end
+end
+
+class MockLogger
+  attr_reader :messages
+
+  def initialize
+    @messages = Hash.new { |h, k| h[k] = [] }
+  end
+
+  def info(message, &block)
+    @messages[:info] << [message, block.call]
+  end
+end
+
 describe 'DataServicesAPI::Service', vcr: true do
+  let(:api_url) do
+    ENV['API_URL'] || 'http://localhost:8888'
+  end
+
   before do
-    VCR.insert_cassette name
+    VCR.insert_cassette(name, record: :new_episodes)
     @service = DataServicesApi::Service.new
   end
 
@@ -12,8 +40,78 @@ describe 'DataServicesAPI::Service', vcr: true do
     VCR.eject_cassette
   end
 
+  it 'should return the service URL' do
+    _(DataServicesApi::Service.new(url: 'https://wimbledon.com').url)
+      .must_equal('https://wimbledon.com')
+  end
+
   it 'should find a dataset by name' do
     dataset = @service.dataset('ukhpi')
     _(dataset.data_api).must_match %r{/landregistry/id/ukhpi}
+  end
+
+  it 'should raise if getting a dataset with no name' do
+    _ do
+      @service.dataset(nil)
+    end.must_raise
+  end
+
+  it 'should retrieve JSON with HTTP GET' do
+    service = DataServicesApi::Service.new(url: 'http://localhost:8080')
+    json = service.api_get_json("#{api_url}/landregistry/id/ukhpi", { '_limit' => 1 })
+    _(json).wont_be_nil
+    _(json['meta']).wont_be_nil
+  end
+
+  it 'should instrument an API call' do
+    instrumenter = MockNotifications.new
+
+    DataServicesApi::Service
+      .new(url: api_url, instrumenter: instrumenter)
+      .api_get_json("#{api_url}/landregistry/id/ukhpi", { '_limit' => 1 })
+
+    instrumentations = instrumenter.instrumentations
+    _(instrumentations.size).must_equal 1
+    _(instrumentations.first.first).must_equal 'response.data_api'
+  end
+
+  it 'should instrument a failed API call' do
+    instrumenter = MockNotifications.new
+
+    _ do
+      DataServicesApi::Service
+        .new(url: 'http://localhost:8765', instrumenter: instrumenter)
+        .api_get_json('http://localhost:8765/landregistry/id/ukhpi', { '_limit' => 1 })
+    end.must_raise
+
+    instrumentations = instrumenter.instrumentations
+    _(instrumentations.size).must_equal 1
+    _(instrumentations.first.first).must_equal 'connection_failure.data_api'
+  end
+
+  it 'should instrument a failed API call' do
+    instrumenter = MockNotifications.new
+
+    _ do
+      DataServicesApi::Service
+        .new(url: api_url, instrumenter: instrumenter)
+        .api_get_json("#{api_url}/ceci/nest/pa/un/page", { '_limit' => 1 })
+    end.must_raise
+
+    instrumentations = instrumenter.instrumentations
+    _(instrumentations.size).must_equal 2
+    _(instrumentations[0].first).must_equal 'response.data_api'
+    _(instrumentations[1].first).must_equal 'service_exception.data_api'
+  end
+
+  it 'should log the call to the data API' do
+    logger = MockLogger.new
+
+    DataServicesApi::Service
+      .new(url: api_url, logger: logger)
+      .api_get_json("#{api_url}/landregistry/id/ukhpi", { '_limit' => 1 })
+
+    # @TODO: add specific constraints on received log messages
+    _(logger.messages).wont_be_empty
   end
 end

--- a/test/data_services_api/service_test.rb
+++ b/test/data_services_api/service_test.rb
@@ -95,7 +95,7 @@ describe 'DataServicesAPI::Service', vcr: true do
     _ do
       DataServicesApi::Service
         .new(url: api_url, instrumenter: instrumenter)
-        .api_get_json("#{api_url}/ceci/nest/pa/un/page", { '_limit' => 1 })
+        .api_get_json("#{api_url}/ceci/nest/pas/une/page", { '_limit' => 1 })
     end.must_raise
 
     instrumentations = instrumenter.instrumentations

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -19,6 +19,7 @@ Bundler.require(:default, :development, :test)
 require 'faraday'
 require 'faraday_middleware'
 require 'byebug'
+require 'mocha/minitest'
 
 VCR.configure do |c|
   c.cassette_library_dir = 'fixtures/vcr_cassettes'


### PR DESCRIPTION
Addresses #15.

Contributes towards epimorphics/hmlr-linked-data#57

This commit adds support for collecting metrics relating to calls to the
data API. We add an dependency for an `instrumenter`, which defaults to
Rails' `ActiveSupport::Notifications`. By publishing events via the
notifier, apps which include `ds-api-ruby` can be configured to collect
those events and feed them to a Prometheus store.

While setting up the dependency injection for the instrumenter, I have
also added a similar hook to inject the logger. This will allow us to
improve the ability of the logger to emit correctly formulated JSON
messages.

This change also adds significantly more unit test coverage for the
elements of `service.rb`.
